### PR TITLE
Make authenticate password input a list to support Multifactor authentication

### DIFF
--- a/pamela.py
+++ b/pamela.py
@@ -345,7 +345,8 @@ def authenticate(username, password=None, service='login', encoding='utf-8',
 
     ``username``: the username to authenticate
 
-    ``password``: the password in plain text
+    ``password``: the password in plain text. It can also be an iterable of
+                  passwords when using multifactor authentication.
                   Defaults to None to use PAM's conversation interface
 
     ``service``: the PAM service to authenticate against.
@@ -369,8 +370,9 @@ def authenticate(username, password=None, service='login', encoding='utf-8',
     if password is None:
         conv_func = default_conv
     else:
-        password = _cast_bytes(password, encoding)
-        conv_func = new_simple_password_conv((password, ), encoding)
+        if isinstance(password, str):
+            password = (password,)
+        conv_func = new_simple_password_conv(password, encoding)
 
     handle = pam_start(service, username, conv_func=conv_func, encoding=encoding)
 


### PR DESCRIPTION
PAM authentication can be done with multiple factors and to enable this with pamela, we only need to make the password input variable a list instead of a single string password.

I have been able to add MFA to Jupyterhub with FreeIPA one-time password by applying this patch.

I know that NERSC (@rcthomas) also have MFA activated on their JupyterHub, although I am not sure if they also modified pamela to achieve it.